### PR TITLE
fixing cli updating + update on any path

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -176,14 +176,10 @@ func getInstallDir() (currentInstallDir string) {
 		log.Errorf("Failed to get current executable: %v", err)
 		os.Exit(1)
 	}
-	currentExecDir, err := filepath.Abs(filepath.Dir(ex))
+	currentInstallDir, err = filepath.Abs(filepath.Dir(ex))
 	if err != nil {
 		log.Errorf("Failed to get current install directory %v", err)
 		os.Exit(1)
-	}
-	currentInstallDir, runaiDir := filepath.Split(currentExecDir)
-	if runaiDir != "runai" {
-		currentInstallDir = currentExecDir
 	}
 	return
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -105,10 +106,11 @@ func NewUpdateCommand() *cobra.Command {
 			}
 
 			log.Infof("Unarchived version in %s", unarchivePath)
+			currentInstallDir := getInstallDir()
 
 			// Install using install script
 			installScriptPath := path.Join(unarchivePath, "install-runai.sh")
-			installCommand := exec.Command(installScriptPath)
+			installCommand := exec.Command(installScriptPath, currentInstallDir)
 			installCommand.Stdout = os.Stdout
 			installCommand.Stderr = os.Stderr
 			err = installCommand.Run()
@@ -166,4 +168,22 @@ func downloadFile(url string, assetName string) (string, error) {
 	log.Infof("Downloaded archive to %s", downloadPath)
 
 	return downloadPath, nil
+}
+
+func getInstallDir() (currentInstallDir string) {
+	ex, err := os.Executable()
+	if err != nil {
+		log.Errorf("Failed to get current executable: %v", err)
+		os.Exit(1)
+	}
+	currentExecDir, err := filepath.Abs(filepath.Dir(ex))
+	if err != nil {
+		log.Errorf("Failed to get current install directory %v", err)
+		os.Exit(1)
+	}
+	currentInstallDir, runaiDir := filepath.Split(currentExecDir)
+	if runaiDir != "runai" {
+		currentInstallDir = currentExecDir
+	}
+	return
 }

--- a/install-runai.sh
+++ b/install-runai.sh
@@ -5,24 +5,26 @@ SCRIPT_NAME=runai
 
 # If first argument is not empty,
 # use that for the installation path
-NEW_SCRIPT_PATH=${1:-/usr/local}
+NEW_SCRIPT_PATH=${1:-/usr/local/runai}
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink "$0" || echo "$0")")"; pwd)"
 
 # Remove old version files
-if [ -d "${NEW_SCRIPT_PATH}/runai" ]; then
-  rm -rf "${NEW_SCRIPT_PATH}/runai"
+if [ -d "${NEW_SCRIPT_PATH}" ]; then
+  rm "${NEW_SCRIPT_PATH}/runai"
+  rm "${NEW_SCRIPT_PATH}/VERSION"
+  rm -rf "${NEW_SCRIPT_PATH}/charts"
 fi
 
 # Create copy destination if it doesn't exist to have directories copied under the folder.
 if [ ! -d "${NEW_SCRIPT_PATH}" ]; then
-    echo "${NEW_SCRIPT_PATH} doesn't exist or is not a directory"
-    ls "${NEW_SCRIPT_PATH}" 2> /dev/null
+    if [ "${NEW_SCRIPT_PATH}" == "/usr/local/runai" ]; then
+        mkdir "${NEW_SCRIPT_PATH}"
+    else
+        echo "${NEW_SCRIPT_PATH} doesn't exist or is not a directory"
+        ls "${NEW_SCRIPT_PATH}" 2> /dev/null
+    fi
 fi
-if [ ! -d "${NEW_SCRIPT_PATH}/runai" ]; then
-    mkdir "${NEW_SCRIPT_PATH}/runai"
-fi
-NEW_SCRIPT_PATH="${NEW_SCRIPT_PATH}/runai"
 
 cp "${SCRIPT_DIR}"/runai "${NEW_SCRIPT_PATH}"
 cp "${SCRIPT_DIR}"/VERSION "${NEW_SCRIPT_PATH}"

--- a/install-runai.sh
+++ b/install-runai.sh
@@ -5,28 +5,33 @@ SCRIPT_NAME=runai
 
 # If first argument is not empty,
 # use that for the installation path
-NEW_SCRIPT_FILES=${1:-/usr/local/runai}
+NEW_SCRIPT_PATH=${1:-/usr/local}
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink "$0" || echo "$0")")"; pwd)"
 
-# Create copy destination if it doesn't exist to have directories copied under the folder.
-if [ ! -d "${NEW_SCRIPT_FILES}" ]; then
-    if [ "$NEW_SCRIPT_FILES" == "/usr/local/runai" ]; then
-        mkdir "${NEW_SCRIPT_FILES}"
-    else
-        echo "${NEW_SCRIPT_FILES} doesn't exist or is not a directory"
-        ls "${NEW_SCRIPT_FILES}" 2> /dev/null
-    fi
+# Remove old version files
+if [ -d "${NEW_SCRIPT_PATH}/runai" ]; then
+  rm -rf "${NEW_SCRIPT_PATH}/runai"
 fi
 
-cp "${SCRIPT_DIR}"/runai "${NEW_SCRIPT_FILES}"
-cp "${SCRIPT_DIR}"/VERSION "${NEW_SCRIPT_FILES}"
-cp -R "${SCRIPT_DIR}"/charts "${NEW_SCRIPT_FILES}"
+# Create copy destination if it doesn't exist to have directories copied under the folder.
+if [ ! -d "${NEW_SCRIPT_PATH}" ]; then
+    echo "${NEW_SCRIPT_PATH} doesn't exist or is not a directory"
+    ls "${NEW_SCRIPT_PATH}" 2> /dev/null
+fi
+if [ ! -d "${NEW_SCRIPT_PATH}/runai" ]; then
+    mkdir "${NEW_SCRIPT_PATH}/runai"
+fi
+NEW_SCRIPT_PATH="${NEW_SCRIPT_PATH}/runai"
 
-if [ "$NEW_SCRIPT_FILES" == "/usr/local/runai" ] ; then
-    ln -sf "${NEW_SCRIPT_FILES}"/"${SCRIPT_NAME}" /usr/local/bin/"${SCRIPT_NAME}"
+cp "${SCRIPT_DIR}"/runai "${NEW_SCRIPT_PATH}"
+cp "${SCRIPT_DIR}"/VERSION "${NEW_SCRIPT_PATH}"
+cp -R "${SCRIPT_DIR}"/charts "${NEW_SCRIPT_PATH}"
+
+if [ "$NEW_SCRIPT_PATH" == "/usr/local/runai" ] ; then
+    ln -sf "${NEW_SCRIPT_PATH}"/"${SCRIPT_NAME}" /usr/local/bin/"${SCRIPT_NAME}"
 else
-    echo "Add ${NEW_SCRIPT_FILES} to your \$PATH: export PATH=\$PATH:${NEW_SCRIPT_FILES}"
+    echo "Add ${NEW_SCRIPT_PATH} to your \$PATH: export PATH=\$PATH:${NEW_SCRIPT_PATH}"
 fi
 
 echo "Run:AI CLI installed successfully!"


### PR DESCRIPTION
Updating failed because I removed the `rm -rf` command that removed the previous installation.
* ~~made sure that we will install in a directory named `runai` in the given path, the prevent accidental deletion of files.~~
* Only deletes the runai files in that directory: `runai, VERSION, charts`
* fixed updating for `/usr/local` and arbitrary path

