### PR TITLE
remove old files with -f ignores nonexistent

### DIFF
--- a/install-runai.sh
+++ b/install-runai.sh
@@ -11,8 +11,8 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink "$0" || echo "$0")")"; pwd)"
 
 # Remove old version files
 if [ -d "${NEW_SCRIPT_PATH}" ]; then
-  rm "${NEW_SCRIPT_PATH}/runai"
-  rm "${NEW_SCRIPT_PATH}/VERSION"
+  rm -f "${NEW_SCRIPT_PATH}/runai"
+  rm -f "${NEW_SCRIPT_PATH}/VERSION"
   rm -rf "${NEW_SCRIPT_PATH}/charts"
 fi
 


### PR DESCRIPTION
```
       -f, --force
              ignore nonexistent files and arguments, never prompt
```